### PR TITLE
Only Set DAG on Change

### DIFF
--- a/AutoDAGsExternalModule.php
+++ b/AutoDAGsExternalModule.php
@@ -8,7 +8,8 @@ class AutoDAGsExternalModule extends \ExternalModules\AbstractExternalModule{
 	// REDCap::getGroupNames() doesn't pick up on added or renamed groups until the next request.
 	private $groupsByID;
 
-	function hook_save_record($project_id, $record){
+	function hook_save_record($project_id, $record, $instrument, $event_id, $group_id, $survey_hash, $response_id, $repeat_instance){
+		$currentGroupId = !is_null($group_id) ? intval($group_id) : $group_id;
 		$dagFieldName = $this->getProjectSetting('dag-field');
 		if(empty($dagFieldName)){
 			return;
@@ -36,7 +37,9 @@ class AutoDAGsExternalModule extends \ExternalModules\AbstractExternalModule{
 			}
 		}
 
-		$this->setDAG($record, $groupId);
+		if ($currentGroupId !== $groupId) {
+			$this->setDAG($record, $groupId);
+		}
 	}
 
 	private function getDAGInfoForFieldValue($value){

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# auto-dags-module
+
+A REDCap External Module that automatically creates, renames, and assigns records to DAGs based on a specified field.
+
+### Note
+
+The field used to generate the DAGs should not be on a repeating instrument or an instrument of a repeating event. If the DAG field is on a repeating instrument, the record's DAG will never be set. If the field is on an instrument of a repeating event, the record's DAG will be set by the first instance of the event, and changes in subsequent instances will not change the record's DAG.


### PR DESCRIPTION
Only set the DAG on records when the DAG has changed. Prevents exceptions when saving repeating instruments.

Add README.md with note about behavior when the auto DAG field is on a repeating instrument or repeating event.