### PR TITLE
Change how label for choice value is looked up

### DIFF
--- a/AutoDAGsExternalModule.php
+++ b/AutoDAGsExternalModule.php
@@ -28,7 +28,9 @@ class AutoDAGsExternalModule extends \ExternalModules\AbstractExternalModule{
 			$groupId = null;
 		}
 		else{
-			$fieldLabel = $this->getChoiceLabel($dagFieldName, $fieldValue);
+			global $Proj;
+			$dagFieldChoices = \parseEnum($Proj->metadata[$dagFieldName]['element_enum']);
+			$fieldLabel = $dagFieldChoices[$fieldValue];
 
 			$groupName = $fieldLabel . self::LABEL_VALUE_SEPARATOR . $fieldValue;
 


### PR DESCRIPTION
AbstractExternalModule::getChoiceLabel() does a lot it doesn't seem necessary to do, including a read of all project data when not provided with a record_id was is the case here. The global function \parseEnum() works for performing the task.