### PR TITLE
Option to restrict assignment to instrument containing DAG field

### DIFF
--- a/AutoDAGsExternalModule.php
+++ b/AutoDAGsExternalModule.php
@@ -9,15 +9,17 @@ class AutoDAGsExternalModule extends \ExternalModules\AbstractExternalModule{
 	private $groupsByID;
 
 	function redcap_save_record($project_id, $record, $instrument, $event_id, $group_id, $survey_hash, $response_id, $repeat_instance){
-		$this->setDAGFromField($project_id, $record, $group_id);
-	}
-
-	function setDAGFromField($project_id, $record, $group_id){
-		$currentGroupId = !is_null($group_id) ? intval($group_id) : $group_id;
 		$dagFieldName = $this->getProjectSetting('dag-field');
 		if(empty($dagFieldName)){
 			return;
 		}
+        $currInstrumentFields = \REDCap::getFieldNames($instrument);
+        if (in_array($dagFieldName, $currInstrumentFields) or !($this->getProjectSetting('curr-instr-only')))
+		{$this->setDAGFromField($project_id, $record, $group_id, $dagFieldName);}
+	}
+
+	function setDAGFromField($project_id, $record, $group_id, $dagFieldName){
+		$currentGroupId = !is_null($group_id) ? intval($group_id) : $group_id;
 
 		$recordIdFieldName = \REDCap::getRecordIdField();
 		$data = json_decode(\REDCap::getData($project_id, 'json', [$record], [$recordIdFieldName, $dagFieldName]))[0];

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ To use:
 1.	Click on configure and choose a field that will trigger the Auto DAGs
     *	Or click on Set DAG for all records (then click ok) 
 1.	This will allow you to set the DAGs for the project.
+1.	Choose whether Auto DAGs should fire on just the instrument containing the DAG field, or on any instrument (default).
 1.	Once the configuration has been saved click Set DAG for all Records under external modules in the left-hand column
 1.	This will allow you to verify the configuration and set the auto DAGS based on your project’s needs.
 1.	You will see the changes, after clicking on DAGS in the left-hand column. 

--- a/config.json
+++ b/config.json
@@ -22,7 +22,11 @@
 			"key": "dag-field",
 			"name": "Choose a field whose values will be used to generate DAGs.  The following field types are currently supported: text, notes, dropdown, and radio button (including yes/no, true/false)",
 			"type": "field-list"
-		}
+		},{
+            "key": "curr-instr-only",
+            "name": "Apply only upon saving instrument containing DAG field? If left unchecked, saving any instrument in a record will trigger DAG assignment",
+            "type": "checkbox"
+        }
 	],
 
 	"links": {


### PR DESCRIPTION
As per [this request](https://community.projectredcap.org/questions/128491/change-autodags-to-fire-on-saving-the-key-instrume.html), this PR adds a config option to restrict Auto DAGs to firing only when the instrument being saved is the instrument containing the Auto DAG field.

This allows a user to manually reassign a record to a new DAG and not have it automatically reassigned back to the DAG created by the Auto DAG field if the record is updated elsewhere. 